### PR TITLE
don't enable detector TEC with default coeffs

### DIFF
--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - 2023-??-?? 2.4.14
     - updates for 1064XL
+    - don't enable detector TEC unless degCToDACCoeffs has a non-default calibration
 - 2023-04-20 2.4.13
     - add warning when encountering unsupported / higher EEPROM format
 - 2022-12-19 2.4.12

--- a/WasatchNET/Spectrometer.cs
+++ b/WasatchNET/Spectrometer.cs
@@ -928,7 +928,7 @@ namespace WasatchNET
             set
             {
                 const Opcodes op = Opcodes.GET_DETECTOR_TEC_ENABLE;
-                if (eeprom.hasCooling && Util.validTECCal(this))
+                if (eeprom.hasCooling)
                 {
                     if (haveCache(op) && value == detectorTECEnabled_)
                         return;
@@ -1970,8 +1970,16 @@ namespace WasatchNET
                 logger.debug("setting TEC setpoint to {0} deg C", degC);
                 detectorTECSetpointDegC = degC;
 
-                logger.debug("enabling detector TEC");
-                detectorTECEnabled = true;
+                if (Util.validTECCal(this))
+                {
+                    logger.debug("enabling detector TEC");
+                    detectorTECEnabled = true;
+                }
+                else
+                {
+                    // user can manually enable it if they wish and feel this is a safe thing to do
+                    logger.info("declining to auto-enable detector TEC because no valid TEC calibration found");
+                }
             }
 
             // if this was intended to be a relatively lightweight "change as

--- a/WasatchNET/Spectrometer.cs
+++ b/WasatchNET/Spectrometer.cs
@@ -928,7 +928,7 @@ namespace WasatchNET
             set
             {
                 const Opcodes op = Opcodes.GET_DETECTOR_TEC_ENABLE;
-                if (eeprom.hasCooling)
+                if (eeprom.hasCooling && Util.validTECCal(this))
                 {
                     if (haveCache(op) && value == detectorTECEnabled_)
                         return;

--- a/WasatchNET/Util.cs
+++ b/WasatchNET/Util.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -278,5 +278,24 @@ namespace WasatchNET
             return temp;
         }
 
+        public static bool validTECCal(Spectrometer spec)
+        {
+            if (!spec.eeprom.hasCooling)
+                return true;
+
+            if (spec is HOCTSpectrometer || spec is BoulderSpectrometer || spec is SPISpectrometer || spec is AndorSpectrometer)
+                return true;
+
+            if (spec.eeprom.degCToDACCoeffs.Length != 3)
+                return false;
+            if (spec.eeprom.degCToDACCoeffs[0] == 2700)
+                return false;
+            if (spec.eeprom.degCToDACCoeffs[1] == 0)
+                return false;
+            if (spec.eeprom.degCToDACCoeffs[2] == 0)
+                return false;
+
+            return true;
+        }
     }
 }

--- a/WasatchNET/Util.cs
+++ b/WasatchNET/Util.cs
@@ -278,6 +278,7 @@ namespace WasatchNET
             return temp;
         }
 
+        // copy-pasted directly from WPSC for consistency
         public static bool validTECCal(Spectrometer spec)
         {
             if (!spec.eeprom.hasCooling)


### PR DESCRIPTION
This can cause an uncalibrated TEC to run the detector out of spec.